### PR TITLE
Feature utils::KifuStrings trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,8 @@ bitintr = "0.3.0"
 once_cell = "1.9.0"
 rand = "0.8.5"
 
+[dev-dependencies]
+itertools = "0.10.3"
+
 [profile.release]
 lto = true

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -1,7 +1,7 @@
 use crate::{Color, PieceType};
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Hands([Hand; Color::NUM]);
 
 impl Hands {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod position;
 mod shogi_move;
 mod square;
 mod tables;
+pub mod utils;
 mod zobrist;
 
 pub use color::Color;

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -3,7 +3,6 @@ use crate::square::Rank;
 use crate::tables::{ATTACK_TABLE, BETWEEN_TABLE};
 use crate::{Color, Move, Piece, PieceType, Position, Square};
 use arrayvec::{ArrayVec, IntoIter};
-use std::ops::Not;
 
 pub struct MoveList(ArrayVec<Move, { MoveList::MAX_LEGAL_MOVES }>);
 
@@ -253,7 +252,7 @@ impl MoveList {
                 // 打ち歩詰めチェック
                 if let Some(sq) = pos.king(!c) {
                     if let Some(to) = ATTACK_TABLE.fu.attack(sq, !c).pop() {
-                        if (*target & to).is_empty().not() && Self::is_uchifuzume(pos, to) {
+                        if !(*target & to).is_empty() && Self::is_uchifuzume(pos, to) {
                             exclude |= to;
                         }
                     }
@@ -278,10 +277,7 @@ impl MoveList {
         }
         // 他の駒が歩を取れる
         let capture_candidates = Self::attackers_to_except_klp(pos, !c, sq);
-        if (capture_candidates & !pos.pinned()[(!c).index()])
-            .is_empty()
-            .not()
-        {
+        if !(capture_candidates & !pos.pinned()[(!c).index()]).is_empty() {
             return false;
         }
         // 玉が逃げられる

--- a/src/position.rs
+++ b/src/position.rs
@@ -11,7 +11,7 @@ use crate::{Color, Move, Piece, Square};
 use std::fmt;
 use std::ops::Not;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct AttackInfo {
     checkers: Bitboard,                     // 王手をかけている駒の位置
     checkables: [Bitboard; PieceType::NUM], // 各駒種が王手になり得る位置
@@ -91,7 +91,7 @@ impl AttackInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct State {
     keys: (Key, Key),
     captured: Option<Piece>,
@@ -109,7 +109,7 @@ impl State {
 }
 
 /// Represents a state of the game.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Position {
     board: [Option<Piece>; Square::NUM],
     hands: Hands,

--- a/src/position.rs
+++ b/src/position.rs
@@ -9,7 +9,6 @@ use crate::tables::{ATTACK_TABLE, BETWEEN_TABLE};
 use crate::zobrist::{Key, ZOBRIST_TABLE};
 use crate::{Color, Move, Piece, Square};
 use std::fmt;
-use std::ops::Not;
 
 #[derive(Debug, Clone)]
 struct AttackInfo {
@@ -206,12 +205,10 @@ impl Position {
         self.state().attack_info.checkers
     }
     pub fn in_check(&self) -> bool {
-        self.checkers().is_empty().not()
+        !self.checkers().is_empty()
     }
     fn checkable(&self, pt: PieceType, sq: Square) -> bool {
-        (self.state().attack_info.checkables[pt.index()] & sq)
-            .is_empty()
-            .not()
+        !(self.state().attack_info.checkables[pt.index()] & sq).is_empty()
     }
     pub fn pinned(&self) -> [Bitboard; Color::NUM] {
         self.state().attack_info.pinned
@@ -346,15 +343,12 @@ impl Position {
             let c = self.side_to_move();
             // 玉が相手の攻撃範囲内に動いてしまう指し手は除外
             if self.piece_on(from) == Some(Piece::from_cp(c, PieceType::OU))
-                && self
-                    .attackers_to(!c, m.to(), &self.occupied())
-                    .is_empty()
-                    .not()
+                && !self.attackers_to(!c, m.to(), &self.occupied()).is_empty()
             {
                 return false;
             }
             // 飛び駒から守っている駒が直線上から外れてしまう指し手は除外
-            if (self.pinned()[c.index()] & from).is_empty().not() {
+            if !(self.pinned()[c.index()] & from).is_empty() {
                 if let Some(sq) = self.king(c) {
                     if (BETWEEN_TABLE[sq.index()][from.index()] & m.to()).is_empty()
                         && (BETWEEN_TABLE[sq.index()][m.to().index()] & from).is_empty()
@@ -385,7 +379,7 @@ impl Position {
                 }
                 // 開き王手
                 let c = self.side_to_move();
-                if (self.pinned()[(!c).index()] & from).is_empty().not() {
+                if !(self.pinned()[(!c).index()] & from).is_empty() {
                     if let Some(sq) = self.king(!c) {
                         return (BETWEEN_TABLE[sq.index()][from.index()] & to).is_empty()
                             && (BETWEEN_TABLE[sq.index()][to.index()] & from).is_empty();

--- a/src/shogi_move.rs
+++ b/src/shogi_move.rs
@@ -19,7 +19,7 @@ pub enum MoveType {
 // ........ ........ .####### ........ : from (0 if drop move)
 // ........ ........ #....... ........ : drop flag
 // ........ ...##### ........ ........ : moved or dropped piece
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Move(u32);
 
 impl Move {

--- a/src/square.rs
+++ b/src/square.rs
@@ -1,7 +1,7 @@
 use crate::{Color, PieceType};
 use std::{fmt, ops};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct File(pub(crate) i8);
 
 impl File {
@@ -66,7 +66,7 @@ impl fmt::Debug for File {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Rank(pub(crate) i8);
 
 impl Rank {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,3 @@
+mod kifu_strings;
+
+pub use self::kifu_strings::KifuStrings;

--- a/src/utils/kifu_strings.rs
+++ b/src/utils/kifu_strings.rs
@@ -174,8 +174,8 @@ fn parts_promotion(m: &Move) -> String {
 fn parts_drop(m: &Move, pos: &Position) -> String {
     let piece = m.piece();
     if m.is_drop()
-        && (pos.pieces_cp(piece.color(), piece.piece_type())
-            & !pos.attackers_to(piece.color(), m.to(), &pos.occupied()))
+        && !(pos.pieces_cp(piece.color(), piece.piece_type())
+            & pos.attackers_to(piece.color(), m.to(), &pos.occupied()))
         .is_empty()
     {
         return String::from("打");

--- a/src/utils/kifu_strings.rs
+++ b/src/utils/kifu_strings.rs
@@ -247,7 +247,7 @@ mod tests {
             WKE, WHI, WFU, EMP, EMP, EMP, BFU, BKA, BKE,
             WKY, EMP, WFU, EMP, EMP, EMP, BFU, EMP, BKY,
         ];
-        let hand_nums = [[0; 7]; 2];
+        let hand_nums = [[0; PieceType::NUM_HAND]; Color::NUM];
         {
             let pos = Position::new(board, hand_nums, Color::Black, 1);
             let test_cases = [(
@@ -424,7 +424,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BGI,
                     EMP, EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -488,7 +488,7 @@ mod tests {
                     EMP, EMP, WGI, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::White,
                 1,
             );
@@ -556,7 +556,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BKI,
                     EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -620,7 +620,7 @@ mod tests {
                     WGI, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::White,
                 1,
             );
@@ -688,7 +688,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, BTO, EMP, BTO,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, BTO, BTO,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -760,7 +760,7 @@ mod tests {
                     WGI, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, WGI, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::White,
                 1,
             );
@@ -836,7 +836,7 @@ mod tests {
                     EMP, EMP, EMP, BRY, EMP, EMP, EMP, EMP, EMP,
                     BRY, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -868,7 +868,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -900,7 +900,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -932,7 +932,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BRY,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BRY,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -964,7 +964,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -996,7 +996,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1028,7 +1028,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, WRY, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1060,7 +1060,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, WRY, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1092,7 +1092,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1124,7 +1124,7 @@ mod tests {
                     EMP, WRY, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     WRY, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1160,7 +1160,7 @@ mod tests {
                     BUM, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     BUM, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1192,7 +1192,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, BUM, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1224,7 +1224,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1256,7 +1256,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BUM,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1288,7 +1288,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1320,7 +1320,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1352,7 +1352,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1384,7 +1384,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, WUM,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1416,7 +1416,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );
@@ -1448,7 +1448,7 @@ mod tests {
                     EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                     EMP, WUM, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
                 ],
-                [[0; 7]; 2],
+                [[0; PieceType::NUM_HAND]; Color::NUM],
                 Color::Black,
                 1,
             );

--- a/src/utils/kifu_strings.rs
+++ b/src/utils/kifu_strings.rs
@@ -1,4 +1,6 @@
-use crate::{Color, File, Move, PieceType, Position, Rank, Square};
+use crate::bitboard::Bitboard;
+use crate::{Color, File, Move, PieceType, Position, Rank};
+use std::cmp::Ordering;
 
 pub trait KifuStrings {
     fn kifu_strings(&self, moves: &[Move]) -> Vec<String>;
@@ -10,55 +12,139 @@ impl KifuStrings for Position {
         let mut pos = self.clone();
         let mut result = Vec::with_capacity(moves.len());
         for (i, &m) in moves.iter().enumerate() {
-            let piece = m.piece();
-            let mut parts = Vec::with_capacity(7);
-            parts.push(color2str(piece.color()));
-            parts.push(square2str(
-                m.to(),
-                if i > 0 { Some(moves[i - 1].to()) } else { None },
+            result.push(move2str(
+                &pos,
+                &m,
+                if i > 0 { Some(&moves[i - 1]) } else { None },
             ));
-            parts.push(pt2str(m.piece().piece_type()));
-            if m.is_promotion() {
-                parts.push(String::from("成"));
-            } else if let Some(from) = m.from() {
-                if m.piece().is_promotable()
-                    && (from.rank().is_opponent_field(piece.color())
-                        || m.to().rank().is_opponent_field(piece.color()))
-                {
-                    parts.push(String::from("不成"));
-                }
-            }
-            // 到達地点に盤上の駒が移動することも、持駒を打つこともできる場合
-            // 盤上の駒が動いた場合は通常の表記と同じ
-            // 持駒を打った場合は「打」と記入
-            else if (self.pieces_cp(piece.color(), piece.piece_type())
-                & !self.attackers_to(piece.color(), m.to(), &self.occupied()))
-            .is_empty()
-            {
-                parts.push(String::from("打"));
-            }
-            result.push(parts.join(""));
-
             pos.do_move(m);
         }
         result
     }
 }
 
-fn color2str(color: Color) -> String {
-    String::from(match color {
+fn move2str(pos: &Position, m: &Move, prev: Option<&Move>) -> String {
+    let parts = vec![
+        parts_color(m),
+        parts_to(m, prev),
+        parts_piece_type(m),
+        parts_direction_relative(m, pos),
+        parts_promotion(m),
+        parts_drop(m, pos),
+    ];
+    parts.join("")
+}
+
+fn parts_color(m: &Move) -> String {
+    String::from(match m.piece().color() {
         Color::Black => "▲",
         Color::White => "△",
     })
 }
 
-fn square2str(sq: Square, prev: Option<Square>) -> String {
-    // 相手の1手前の指し手と同地点に移動した場合（＝その駒を取った場合）、「同」と記入。
-    if Some(sq) == prev {
+// 相手の1手前の指し手と同地点に移動した場合（＝その駒を取った場合）、「同」と記入。
+fn parts_to(m: &Move, prev: Option<&Move>) -> String {
+    let to = m.to();
+    if prev.map_or(false, |prev| prev.to() == to) {
         String::from("同")
     } else {
-        format!("{}{}", file2str(sq.file()), rank2str(sq.rank()))
+        format!("{}{}", file2str(to.file()), rank2str(to.rank()))
     }
+}
+
+fn parts_piece_type(m: &Move) -> String {
+    String::from(match m.piece().piece_type() {
+        PieceType::FU => "歩",
+        PieceType::KY => "香",
+        PieceType::KE => "桂",
+        PieceType::GI => "銀",
+        PieceType::KI => "金",
+        PieceType::KA => "角",
+        PieceType::HI => "飛",
+        PieceType::OU => "玉",
+        PieceType::TO => "と",
+        PieceType::NY => "成香",
+        PieceType::NK => "成桂",
+        PieceType::NG => "成銀",
+        PieceType::UM => "馬",
+        PieceType::RY => "竜",
+        _ => unreachable!(),
+    })
+}
+
+fn parts_direction_relative(m: &Move, pos: &Position) -> String {
+    let mut ret = String::new();
+    if let Some(from) = m.from() {
+        let piece = m.piece();
+        let bb = pos.pieces_cp(piece.color(), piece.piece_type())
+            & pos.attackers_to(piece.color(), m.to(), &pos.occupied())
+            & !Bitboard::from_square(from);
+        let (mut same_files, mut same_ranks) = (false, false);
+        for sq in bb {
+            if sq.file() == from.file() {
+                same_files = true;
+            }
+            if sq.rank() == from.rank() {
+                same_ranks = true;
+            }
+        }
+        if !bb.is_empty() {
+            let (mut file_diff, mut rank_diff) =
+                (m.to().file() - from.file(), m.to().rank() - from.rank());
+            if piece.color() == Color::White {
+                file_diff *= -1;
+                rank_diff *= -1;
+            };
+            // 到達地点に2枚の同じ駒が動ける場合、動作でどの駒が動いたかわからない時は、「左」「右」を記入します。
+            if same_ranks {
+                ret += match file_diff.cmp(&0) {
+                    Ordering::Less => "左",
+                    Ordering::Equal => "直",
+                    Ordering::Greater => "右",
+                };
+            }
+            // 到達地点に複数の同じ駒が動ける場合、「上」または「寄」または「引」を記入します。
+            if !same_ranks || (same_files && from.file() != m.to().file()) {
+                ret += match rank_diff.cmp(&0) {
+                    Ordering::Less => "上",
+                    Ordering::Equal => "寄",
+                    Ordering::Greater => "引",
+                };
+            }
+        }
+    }
+    ret
+}
+
+// 到達地点に移動することによって「成る」ことが可能な場合、成るか成らないかを区別するために「成」「不成」いずれかを追加記入します。
+fn parts_promotion(m: &Move) -> String {
+    if m.is_promotion() {
+        return String::from("成");
+    } else if let Some(from) = m.from() {
+        let piece = m.piece();
+        if piece.is_promotable()
+            && (from.rank().is_opponent_field(piece.color())
+                || m.to().rank().is_opponent_field(piece.color()))
+        {
+            return String::from("不成");
+        }
+    }
+    String::new()
+}
+
+// 到達地点に盤上の駒が移動することも、持駒を打つこともできる場合
+// 盤上の駒が動いた場合は通常の表記と同じ
+// 持駒を打った場合は「打」と記入
+fn parts_drop(m: &Move, pos: &Position) -> String {
+    let piece = m.piece();
+    if m.is_drop()
+        && (pos.pieces_cp(piece.color(), piece.piece_type())
+            & !pos.attackers_to(piece.color(), m.to(), &pos.occupied()))
+        .is_empty()
+    {
+        return String::from("打");
+    }
+    String::new()
 }
 
 fn file2str(file: File) -> String {
@@ -87,26 +173,6 @@ fn rank2str(rank: Rank) -> String {
         Rank::RANK7 => "七",
         Rank::RANK8 => "八",
         Rank::RANK9 => "九",
-        _ => unreachable!(),
-    })
-}
-
-fn pt2str(pt: PieceType) -> String {
-    String::from(match pt {
-        PieceType::FU => "歩",
-        PieceType::KY => "香",
-        PieceType::KE => "桂",
-        PieceType::GI => "銀",
-        PieceType::KI => "金",
-        PieceType::KA => "角",
-        PieceType::HI => "飛",
-        PieceType::OU => "玉",
-        PieceType::TO => "と",
-        PieceType::NY => "成香",
-        PieceType::NK => "成桂",
-        PieceType::NG => "成銀",
-        PieceType::UM => "馬",
-        PieceType::RY => "竜",
         _ => unreachable!(),
     })
 }
@@ -163,8 +229,8 @@ mod tests {
             let pos = Position::new(board, hand_nums, Color::White, 1);
             let test_cases = [(
                 vec![
-                    Move::new_normal(Square::SQ56, Square::SQ55, false, Piece::WFU),
-                    Move::new_normal(Square::SQ54, Square::SQ55, false, Piece::BFU),
+                    Move::new_normal(Square::SQ54, Square::SQ55, false, Piece::WFU),
+                    Move::new_normal(Square::SQ56, Square::SQ55, false, Piece::BFU),
                 ],
                 vec!["△5五歩", "▲同歩"],
             )];
@@ -264,7 +330,455 @@ mod tests {
                     "▲4五銀",
                 ),
             ];
-            for &(m, expected) in test_cases.iter() {
+            for (m, expected) in test_cases {
+                assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
+            }
+        }
+        {
+            let pos = Position::new(board, hand_nums, Color::White, 1);
+            let test_cases = [
+                (
+                    Move::new_normal(Square::SQ57, Square::SQ68, false, Piece::WGI),
+                    "△6八銀不成",
+                ),
+                (
+                    Move::new_normal(Square::SQ57, Square::SQ68, true, Piece::WGI),
+                    "△6八銀成",
+                ),
+                (
+                    Move::new_normal(Square::SQ57, Square::SQ66, false, Piece::WGI),
+                    "△6六銀不成",
+                ),
+                (
+                    Move::new_normal(Square::SQ57, Square::SQ66, true, Piece::WGI),
+                    "△6六銀成",
+                ),
+                (
+                    Move::new_normal(Square::SQ56, Square::SQ67, false, Piece::WGI),
+                    "△6七銀不成",
+                ),
+                (
+                    Move::new_normal(Square::SQ56, Square::SQ67, true, Piece::WGI),
+                    "△6七銀成",
+                ),
+                (
+                    Move::new_normal(Square::SQ56, Square::SQ65, false, Piece::WGI),
+                    "△6五銀",
+                ),
+            ];
+            for (m, expected) in test_cases {
+                assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
+            }
+        }
+    }
+
+    #[test]
+    fn 上_寄_引() {
+        {
+            #[rustfmt::skip]
+            let pos = Position::new(
+                [
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, BGI, EMP, EMP,
+                    BKI, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, BKI, EMP, BKI, EMP, EMP, EMP, BGI,
+                    EMP, EMP, EMP, EMP, EMP, BKI, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, BKI, EMP, EMP, EMP, EMP, BGI, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BGI,
+                    EMP, EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP,
+                ],
+                [[0; 7]; 2],
+                Color::Black,
+                1,
+            );
+            let test_cases = [
+                (
+                    Move::new_normal(Square::SQ93, Square::SQ82, false, Piece::BKI),
+                    "▲8二金上",
+                ),
+                (
+                    Move::new_normal(Square::SQ72, Square::SQ82, false, Piece::BKI),
+                    "▲8二金寄",
+                ),
+                (
+                    Move::new_normal(Square::SQ43, Square::SQ32, false, Piece::BKI),
+                    "▲3二金上",
+                ),
+                (
+                    Move::new_normal(Square::SQ31, Square::SQ32, false, Piece::BKI),
+                    "▲3二金引",
+                ),
+                (
+                    Move::new_normal(Square::SQ56, Square::SQ55, false, Piece::BKI),
+                    "▲5五金上",
+                ),
+                (
+                    Move::new_normal(Square::SQ45, Square::SQ55, false, Piece::BKI),
+                    "▲5五金寄",
+                ),
+                (
+                    Move::new_normal(Square::SQ89, Square::SQ88, false, Piece::BGI),
+                    "▲8八銀上",
+                ),
+                (
+                    Move::new_normal(Square::SQ77, Square::SQ88, false, Piece::BGI),
+                    "▲8八銀引",
+                ),
+                (
+                    Move::new_normal(Square::SQ49, Square::SQ38, false, Piece::BGI),
+                    "▲3八銀上",
+                ),
+                (
+                    Move::new_normal(Square::SQ27, Square::SQ38, false, Piece::BGI),
+                    "▲3八銀引",
+                ),
+            ];
+            for (m, expected) in test_cases {
+                assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
+            }
+        }
+        {
+            #[rustfmt::skip]
+            let pos = Position::new(
+                [
+                    EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP, EMP,
+                    WGI, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, WGI, EMP, EMP, EMP, EMP, WKI, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, WKI, EMP, EMP, EMP, EMP, EMP,
+                    WGI, EMP, EMP, EMP, WKI, EMP, WKI, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, WKI,
+                    EMP, EMP, WGI, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                ],
+                [[0; 7]; 2],
+                Color::White,
+                1,
+            );
+            let test_cases = [
+                (
+                    Move::new_normal(Square::SQ17, Square::SQ28, false, Piece::WKI),
+                    "△2八金上",
+                ),
+                (
+                    Move::new_normal(Square::SQ38, Square::SQ28, false, Piece::WKI),
+                    "△2八金寄",
+                ),
+                (
+                    Move::new_normal(Square::SQ67, Square::SQ78, false, Piece::WKI),
+                    "△7八金上",
+                ),
+                (
+                    Move::new_normal(Square::SQ79, Square::SQ78, false, Piece::WKI),
+                    "△7八金引",
+                ),
+                (
+                    Move::new_normal(Square::SQ54, Square::SQ55, false, Piece::WKI),
+                    "△5五金上",
+                ),
+                (
+                    Move::new_normal(Square::SQ65, Square::SQ55, false, Piece::WKI),
+                    "△5五金寄",
+                ),
+                (
+                    Move::new_normal(Square::SQ21, Square::SQ22, false, Piece::WGI),
+                    "△2二銀上",
+                ),
+                (
+                    Move::new_normal(Square::SQ33, Square::SQ22, false, Piece::WGI),
+                    "△2二銀引",
+                ),
+                (
+                    Move::new_normal(Square::SQ61, Square::SQ72, false, Piece::WGI),
+                    "△7二銀上",
+                ),
+                (
+                    Move::new_normal(Square::SQ83, Square::SQ72, false, Piece::WGI),
+                    "△7二銀引",
+                ),
+            ];
+            for (m, expected) in test_cases {
+                assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
+            }
+        }
+    }
+
+    #[test]
+    fn 左_直_右() {
+        {
+            #[rustfmt::skip]
+            let pos = Position::new(
+                [
+                    EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BGI,
+                    EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP, BGI,
+                    EMP, EMP, EMP, EMP, BGI, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, BGI, EMP, EMP, EMP, EMP,
+                    EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP, BKI,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BKI,
+                    EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                ],
+                [[0; 7]; 2],
+                Color::Black,
+                1,
+            );
+            let test_cases = [
+                (
+                    Move::new_normal(Square::SQ92, Square::SQ81, false, Piece::BKI),
+                    "▲8一金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ72, Square::SQ81, false, Piece::BKI),
+                    "▲8一金右",
+                ),
+                (
+                    Move::new_normal(Square::SQ32, Square::SQ22, false, Piece::BKI),
+                    "▲2二金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ12, Square::SQ22, false, Piece::BKI),
+                    "▲2二金右",
+                ),
+                (
+                    Move::new_normal(Square::SQ65, Square::SQ56, false, Piece::BGI),
+                    "▲5六銀左",
+                ),
+                (
+                    Move::new_normal(Square::SQ45, Square::SQ56, false, Piece::BGI),
+                    "▲5六銀右",
+                ),
+                (
+                    Move::new_normal(Square::SQ89, Square::SQ78, false, Piece::BKI),
+                    "▲7八金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ79, Square::SQ78, false, Piece::BKI),
+                    "▲7八金直",
+                ),
+                (
+                    Move::new_normal(Square::SQ39, Square::SQ38, false, Piece::BGI),
+                    "▲3八銀直",
+                ),
+                (
+                    Move::new_normal(Square::SQ29, Square::SQ38, false, Piece::BGI),
+                    "▲3八銀右",
+                ),
+            ];
+            for (m, expected) in test_cases {
+                assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
+            }
+        }
+        {
+            #[rustfmt::skip]
+            let pos = Position::new(
+                [
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP,
+                    WKI, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    WKI, EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP,
+                    EMP, EMP, EMP, EMP, WGI, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, WGI, EMP, EMP, EMP, EMP,
+                    WGI, EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP,
+                    WGI, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP,
+                ],
+                [[0; 7]; 2],
+                Color::White,
+                1,
+            );
+            let test_cases = [
+                (
+                    Move::new_normal(Square::SQ18, Square::SQ29, false, Piece::WKI),
+                    "△2九金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ38, Square::SQ29, false, Piece::WKI),
+                    "△2九金右",
+                ),
+                (
+                    Move::new_normal(Square::SQ78, Square::SQ88, false, Piece::WKI),
+                    "△8八金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ98, Square::SQ88, false, Piece::WKI),
+                    "△8八金右",
+                ),
+                (
+                    Move::new_normal(Square::SQ45, Square::SQ54, false, Piece::WGI),
+                    "△5四銀左",
+                ),
+                (
+                    Move::new_normal(Square::SQ65, Square::SQ54, false, Piece::WGI),
+                    "△5四銀右",
+                ),
+                (
+                    Move::new_normal(Square::SQ21, Square::SQ32, false, Piece::WKI),
+                    "△3二金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ31, Square::SQ32, false, Piece::WKI),
+                    "△3二金直",
+                ),
+                (
+                    Move::new_normal(Square::SQ71, Square::SQ72, false, Piece::WGI),
+                    "△7二銀直",
+                ),
+                (
+                    Move::new_normal(Square::SQ81, Square::SQ72, false, Piece::WGI),
+                    "△7二銀右",
+                ),
+            ];
+            for (m, expected) in test_cases {
+                assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
+            }
+        }
+    }
+
+    #[test]
+    fn 上寄引_左直右() {
+        {
+            #[rustfmt::skip]
+            let pos = Position::new(
+                [
+                    EMP, EMP, EMP, EMP, EMP, EMP, BGI, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BGI,
+                    EMP, EMP, EMP, EMP, EMP, EMP, BGI, EMP, BGI,
+                    EMP, EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, BKI, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP, BTO,
+                    EMP, EMP, EMP, EMP, EMP, EMP, BTO, EMP, BTO,
+                    EMP, EMP, EMP, EMP, EMP, EMP, EMP, BTO, BTO,
+                ],
+                [[0; 7]; 2],
+                Color::Black,
+                1,
+            );
+            let test_cases = [
+                (
+                    Move::new_normal(Square::SQ63, Square::SQ52, false, Piece::BKI),
+                    "▲5二金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ53, Square::SQ52, false, Piece::BKI),
+                    "▲5二金直",
+                ),
+                (
+                    Move::new_normal(Square::SQ43, Square::SQ52, false, Piece::BKI),
+                    "▲5二金右",
+                ),
+                (
+                    Move::new_normal(Square::SQ79, Square::SQ88, false, Piece::BTO),
+                    "▲8八と右",
+                ),
+                (
+                    Move::new_normal(Square::SQ89, Square::SQ88, false, Piece::BTO),
+                    "▲8八と直",
+                ),
+                (
+                    Move::new_normal(Square::SQ99, Square::SQ88, false, Piece::BTO),
+                    "▲8八と左上",
+                ),
+                (
+                    Move::new_normal(Square::SQ98, Square::SQ88, false, Piece::BTO),
+                    "▲8八と寄",
+                ),
+                (
+                    Move::new_normal(Square::SQ87, Square::SQ88, false, Piece::BTO),
+                    "▲8八と引",
+                ),
+                (
+                    Move::new_normal(Square::SQ29, Square::SQ28, false, Piece::BGI),
+                    "▲2八銀直",
+                ),
+                (
+                    Move::new_normal(Square::SQ17, Square::SQ28, false, Piece::BGI),
+                    "▲2八銀右",
+                ),
+                (
+                    Move::new_normal(Square::SQ39, Square::SQ28, false, Piece::BGI),
+                    "▲2八銀左上",
+                ),
+                (
+                    Move::new_normal(Square::SQ37, Square::SQ28, false, Piece::BGI),
+                    "▲2八銀左引",
+                ),
+            ];
+            for (m, expected) in test_cases {
+                assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
+            }
+        }
+        {
+            #[rustfmt::skip]
+            let pos = Position::new(
+                [
+                    WTO, WTO, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    WTO, EMP, WTO, EMP, EMP, EMP, EMP, EMP, EMP,
+                    WTO, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP, EMP,
+                    EMP, EMP, EMP, EMP, EMP, EMP, WKI, EMP, EMP,
+                    WGI, EMP, WGI, EMP, EMP, EMP, EMP, EMP, EMP,
+                    WGI, EMP, EMP, EMP, EMP, EMP, EMP, EMP, EMP,
+                    EMP, EMP, WGI, EMP, EMP, EMP, EMP, EMP, EMP,
+                ],
+                [[0; 7]; 2],
+                Color::White,
+                1,
+            );
+            let test_cases = [
+                (
+                    Move::new_normal(Square::SQ47, Square::SQ58, false, Piece::WKI),
+                    "△5八金左",
+                ),
+                (
+                    Move::new_normal(Square::SQ57, Square::SQ58, false, Piece::WKI),
+                    "△5八金直",
+                ),
+                (
+                    Move::new_normal(Square::SQ67, Square::SQ58, false, Piece::WKI),
+                    "△5八金右",
+                ),
+                (
+                    Move::new_normal(Square::SQ31, Square::SQ22, false, Piece::WTO),
+                    "△2二と右",
+                ),
+                (
+                    Move::new_normal(Square::SQ21, Square::SQ22, false, Piece::WTO),
+                    "△2二と直",
+                ),
+                (
+                    Move::new_normal(Square::SQ11, Square::SQ22, false, Piece::WTO),
+                    "△2二と左上",
+                ),
+                (
+                    Move::new_normal(Square::SQ12, Square::SQ22, false, Piece::WTO),
+                    "△2二と寄",
+                ),
+                (
+                    Move::new_normal(Square::SQ23, Square::SQ22, false, Piece::WTO),
+                    "△2二と引",
+                ),
+                (
+                    Move::new_normal(Square::SQ81, Square::SQ82, false, Piece::WGI),
+                    "△8二銀直",
+                ),
+                (
+                    Move::new_normal(Square::SQ93, Square::SQ82, false, Piece::WGI),
+                    "△8二銀右",
+                ),
+                (
+                    Move::new_normal(Square::SQ71, Square::SQ82, false, Piece::WGI),
+                    "△8二銀左上",
+                ),
+                (
+                    Move::new_normal(Square::SQ73, Square::SQ82, false, Piece::WGI),
+                    "△8二銀左引",
+                ),
+            ];
+            for (m, expected) in test_cases {
                 assert_eq!(vec![expected], pos.kifu_strings(&[m]), "{m}");
             }
         }

--- a/src/utils/kifu_strings.rs
+++ b/src/utils/kifu_strings.rs
@@ -1,0 +1,118 @@
+use crate::{Color, File, Move, PieceType, Position, Rank, Square};
+
+pub trait KifuStrings {
+    fn kifu_strings(&self, moves: &[Move]) -> Vec<String>;
+}
+
+impl KifuStrings for Position {
+    // https://www.shogi.or.jp/faq/kihuhyouki.html
+    fn kifu_strings(&self, moves: &[Move]) -> Vec<String> {
+        let mut pos = self.clone();
+        let mut result = Vec::with_capacity(moves.len());
+        for (i, &m) in moves.iter().enumerate() {
+            let mut parts = Vec::with_capacity(7);
+            parts.push(color2str(m.piece().color()));
+            parts.push(square2str(
+                m.to(),
+                if i > 0 { Some(moves[i - 1].to()) } else { None },
+            ));
+            parts.push(pt2str(m.piece().piece_type()));
+            if m.is_promotion() {
+                parts.push(String::from("成"));
+            } else if m.to().rank().is_opponent_field(m.piece().color()) {
+                parts.push(String::from("不成"));
+            }
+            result.push(parts.join(""));
+
+            pos.do_move(m);
+        }
+        result
+    }
+}
+
+fn color2str(color: Color) -> String {
+    String::from(match color {
+        Color::Black => "▲",
+        Color::White => "△",
+    })
+}
+
+fn square2str(sq: Square, prev: Option<Square>) -> String {
+    if Some(sq) == prev {
+        String::from("同")
+    } else {
+        format!("{}{}", file2str(sq.file()), rank2str(sq.rank()))
+    }
+}
+
+fn file2str(file: File) -> String {
+    String::from(match file {
+        File::FILE1 => "1",
+        File::FILE2 => "2",
+        File::FILE3 => "3",
+        File::FILE4 => "4",
+        File::FILE5 => "5",
+        File::FILE6 => "6",
+        File::FILE7 => "7",
+        File::FILE8 => "8",
+        File::FILE9 => "9",
+        _ => unreachable!(),
+    })
+}
+
+fn rank2str(rank: Rank) -> String {
+    String::from(match rank {
+        Rank::RANK1 => "一",
+        Rank::RANK2 => "二",
+        Rank::RANK3 => "三",
+        Rank::RANK4 => "四",
+        Rank::RANK5 => "五",
+        Rank::RANK6 => "六",
+        Rank::RANK7 => "七",
+        Rank::RANK8 => "八",
+        Rank::RANK9 => "九",
+        _ => unreachable!(),
+    })
+}
+
+fn pt2str(pt: PieceType) -> String {
+    String::from(match pt {
+        PieceType::FU => "歩",
+        PieceType::KY => "香",
+        PieceType::KE => "桂",
+        PieceType::GI => "銀",
+        PieceType::KI => "金",
+        PieceType::KA => "角",
+        PieceType::HI => "飛",
+        PieceType::OU => "玉",
+        PieceType::TO => "と",
+        PieceType::NY => "成香",
+        PieceType::NK => "成桂",
+        PieceType::NG => "成銀",
+        PieceType::UM => "馬",
+        PieceType::RY => "竜",
+        _ => unreachable!(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Piece, Square};
+
+    #[test]
+    fn from_default() {
+        let pos = Position::default();
+        let moves = vec![
+            Move::new_normal(Square::SQ77, Square::SQ76, false, Piece::BFU),
+            Move::new_normal(Square::SQ33, Square::SQ34, false, Piece::WFU),
+            Move::new_normal(Square::SQ88, Square::SQ22, false, Piece::BKA),
+            Move::new_normal(Square::SQ31, Square::SQ22, false, Piece::WGI),
+            Move::new_drop(Square::SQ88, Piece::BKA),
+        ];
+        assert_eq!(
+            vec!["▲7六歩", "△3四歩", "▲2二角不成", "△同銀", "▲8八角"],
+            pos.kifu_strings(&moves)
+        );
+    }
+}

--- a/src/utils/kifu_strings.rs
+++ b/src/utils/kifu_strings.rs
@@ -1,5 +1,4 @@
 use crate::{Color, File, Move, PieceType, Position, Rank, Square};
-use std::ops::Not;
 
 pub trait KifuStrings {
     fn kifu_strings(&self, moves: &[Move]) -> Vec<String>;
@@ -33,9 +32,8 @@ impl KifuStrings for Position {
             // 盤上の駒が動いた場合は通常の表記と同じ
             // 持駒を打った場合は「打」と記入
             else if (self.pieces_cp(piece.color(), piece.piece_type())
-                & self.attackers_to(piece.color(), m.to(), &self.occupied()))
+                & !self.attackers_to(piece.color(), m.to(), &self.occupied()))
             .is_empty()
-            .not()
             {
                 parts.push(String::from("打"));
             }


### PR DESCRIPTION
- https://www.shogi.or.jp/faq/kihuhyouki.html

example:
```rust
use yasai::utils::KifuStrings;
use yasai::{Move, Piece, Position, Square};

fn main() {
    let pos = Position::default();
    let moves = vec![
        Move::new_normal(Square::SQ77, Square::SQ76, false, Piece::BFU),
        Move::new_normal(Square::SQ33, Square::SQ34, false, Piece::WFU),
        Move::new_normal(Square::SQ88, Square::SQ22, true, Piece::BKA),
        Move::new_normal(Square::SQ31, Square::SQ22, false, Piece::WGI),
        Move::new_drop(Square::SQ15, Piece::BKA),
    ];
    println!("{:?}", pos.kifu_strings(&moves));
}
```

results:
```
["▲7六歩", "△3四歩", "▲2二角成", "△同銀", "▲1五角"]
```