### PR TITLE
Optimizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
 [build]
 rustflags = ["-C", "target-cpu=native"]
-
-[target.'cfg(all(target_arch = "x86_64", target_feature = "lzcnt"))']
-rustflags = ["-C", "target-cpu=native", "-C", "target-feature=+lzcnt"]

--- a/src/bitboard/core.rs
+++ b/src/bitboard/core.rs
@@ -94,20 +94,25 @@ const MASKED_BBS: [Bitboard; Square::NUM + 2] = [
 ];
 
 impl Occupied for Bitboard {
+    #[inline(always)]
     fn sliding_positive(&self, mask: &Self) -> Self {
         let tz = (*self & *mask | BB_9I).to_u128().trailing_zeros();
         *mask & MASKED_BBS[tz as usize + 1]
     }
+    #[inline(always)]
     fn sliding_negative(&self, mask: &Self) -> Self {
         let lz = (*self & *mask | BB_1A).to_u128().leading_zeros();
         *mask & !MASKED_BBS[127 - lz as usize]
     }
+    #[inline(always)]
     fn sliding_positives(&self, masks: &[Self; 2]) -> Self {
         self.sliding_positive(&masks[0]) | self.sliding_positive(&masks[1])
     }
+    #[inline(always)]
     fn sliding_negatives(&self, masks: &[Self; 2]) -> Self {
         self.sliding_negative(&masks[0]) | self.sliding_negative(&masks[1])
     }
+    #[inline(always)]
     fn vacant_files(&self) -> Self {
         let bb = unsafe { Self::from_u128_unchecked(VACANT_MASK_VALUE - self.to_u128()) };
         VACANT_MASK

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -93,7 +93,7 @@ impl Position {
             (unsafe { self.piece_bitboard(Piece::B_P).shift_up(1) }, 1),
             (unsafe { self.piece_bitboard(Piece::W_P).shift_down(1) }, !0),
         ][c.array_index()];
-        for to in to_bb & *target {
+        for to in to_bb & target {
             let from = unsafe { Square::from_u8_unchecked(to.index().wrapping_add(delta)) };
             if PROMOTABLE[to.array_index()][c.array_index()] {
                 av.push(Move::Normal {
@@ -120,7 +120,7 @@ impl Position {
     fn generate_for_ky(&self, av: &mut ArrayVec<Move, MAX_LEGAL_MOVES>, target: &Bitboard) {
         let c = self.side_to_move();
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::Lance) {
-            for to in ATTACK_TABLE.ky.attack(from, c, &self.occupied_bitboard()) & *target {
+            for to in ATTACK_TABLE.ky.attack(from, c, &self.occupied_bitboard()) & target {
                 if PROMOTABLE[to.array_index()][c.array_index()] {
                     av.push(Move::Normal {
                         from,
@@ -147,7 +147,7 @@ impl Position {
     fn generate_for_ke(&self, av: &mut ArrayVec<Move, MAX_LEGAL_MOVES>, target: &Bitboard) {
         let c = self.side_to_move();
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::Knight) {
-            for to in ATTACK_TABLE.ke.attack(from, c) & *target {
+            for to in ATTACK_TABLE.ke.attack(from, c) & target {
                 if PROMOTABLE[to.array_index()][c.array_index()] {
                     av.push(Move::Normal {
                         from,
@@ -175,7 +175,7 @@ impl Position {
         let c = self.side_to_move();
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::Silver) {
             let from_is_opponent_field = PROMOTABLE[from.array_index()][c.array_index()];
-            for to in ATTACK_TABLE.gi.attack(from, c) & *target {
+            for to in ATTACK_TABLE.gi.attack(from, c) & target {
                 av.push(Move::Normal {
                     from,
                     to,
@@ -195,7 +195,7 @@ impl Position {
         let c = self.side_to_move();
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::Bishop) {
             let from_is_opponent_field = PROMOTABLE[from.array_index()][c.array_index()];
-            for to in ATTACK_TABLE.ka.attack(from, &self.occupied_bitboard()) & *target {
+            for to in ATTACK_TABLE.ka.attack(from, &self.occupied_bitboard()) & target {
                 av.push(Move::Normal {
                     from,
                     to,
@@ -215,7 +215,7 @@ impl Position {
         let c = self.side_to_move();
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::Rook) {
             let from_is_opponent_field = PROMOTABLE[from.array_index()][c.array_index()];
-            for to in ATTACK_TABLE.hi.attack(from, &self.occupied_bitboard()) & *target {
+            for to in ATTACK_TABLE.hi.attack(from, &self.occupied_bitboard()) & target {
                 av.push(Move::Normal {
                     from,
                     to,
@@ -240,7 +240,7 @@ impl Position {
             | self.piece_kind_bitboard(PieceKind::ProSilver))
             & self.player_bitboard(c)
         {
-            for to in ATTACK_TABLE.ki.attack(from, c) & *target {
+            for to in ATTACK_TABLE.ki.attack(from, c) & target {
                 av.push(Move::Normal {
                     from,
                     to,
@@ -252,7 +252,7 @@ impl Position {
     fn generate_for_ou(&self, av: &mut ArrayVec<Move, MAX_LEGAL_MOVES>, target: &Bitboard) {
         let c = self.side_to_move();
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::King) {
-            for to in ATTACK_TABLE.ou.attack(from, c) & *target {
+            for to in ATTACK_TABLE.ou.attack(from, c) & target {
                 av.push(Move::Normal {
                     from,
                     to,
@@ -266,7 +266,7 @@ impl Position {
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::ProBishop) {
             for to in (ATTACK_TABLE.ka.attack(from, &self.occupied_bitboard())
                 | ATTACK_TABLE.ou.attack(from, c))
-                & *target
+                & target
             {
                 av.push(Move::Normal {
                     from,
@@ -281,7 +281,7 @@ impl Position {
         for from in self.player_bitboard(c) & self.piece_kind_bitboard(PieceKind::ProRook) {
             for to in (ATTACK_TABLE.hi.attack(from, &self.occupied_bitboard())
                 | ATTACK_TABLE.ou.attack(from, c))
-                & *target
+                & target
             {
                 av.push(Move::Normal {
                     from,

--- a/src/position.rs
+++ b/src/position.rs
@@ -40,24 +40,31 @@ impl Position {
             states: vec![state],
         }
     }
+    #[inline(always)]
     pub fn side_to_move(&self) -> Color {
         self.inner.side
     }
+    #[inline(always)]
     pub fn ply(&self) -> u16 {
         self.inner.ply
     }
+    #[inline(always)]
     pub fn hand(&self, color: Color) -> Hand {
         self.inner.hands[color.array_index()]
     }
+    #[inline(always)]
     pub fn piece_at(&self, sq: Square) -> Option<Piece> {
         self.inner.piece_at(sq)
     }
+    #[inline(always)]
     pub fn key(&self) -> u64 {
         (self.state().keys.0 ^ self.state().keys.1).value()
     }
+    #[inline(always)]
     pub fn keys(&self) -> (u64, u64) {
         (self.state().keys.0.value(), self.state().keys.1.value())
     }
+    #[inline(always)]
     pub fn in_check(&self) -> bool {
         !self.checkers().is_empty()
     }
@@ -210,37 +217,48 @@ impl Position {
         self.inner.ply -= 1;
         self.states.pop();
     }
+    #[inline(always)]
     pub(crate) fn player_bitboard(&self, c: Color) -> Bitboard {
         self.inner.player_bb[c.array_index()]
     }
+    #[inline(always)]
     pub(crate) fn piece_kind_bitboard(&self, pk: PieceKind) -> Bitboard {
         self.inner.piece_bb[pk.array_index()]
     }
+    #[inline(always)]
     pub(crate) fn piece_bitboard(&self, p: Piece) -> Bitboard {
         let (pk, c) = p.to_parts();
         self.inner.piece_bb[pk.array_index()] & self.inner.player_bb[c.array_index()]
     }
+    #[inline(always)]
     pub(crate) fn occupied_bitboard(&self) -> Bitboard {
         self.inner.occupied_bitboard()
     }
+    #[inline(always)]
     pub(crate) fn king_position(&self, c: Color) -> Option<Square> {
         self.inner.king_position(c)
     }
+    #[inline(always)]
     pub(crate) fn captured(&self) -> Option<Piece> {
         self.state().captured
     }
+    #[inline(always)]
     pub(crate) fn last_moved(&self) -> Option<Piece> {
         self.state().last_moved
     }
+    #[inline(always)]
     pub(crate) fn checkers(&self) -> Bitboard {
         self.state().attack_info.checkers()
     }
+    #[inline(always)]
     pub(crate) fn pinned(&self, c: Color) -> Bitboard {
         self.state().attack_info.pinned(c)
     }
+    #[inline(always)]
     fn state(&self) -> &State {
         self.states.last().expect("empty states")
     }
+    #[inline(always)]
     fn checkable(&self, pk: PieceKind, sq: Square) -> bool {
         self.state().attack_info.checkable(pk, sq)
     }
@@ -263,29 +281,34 @@ pub(crate) struct PartialPosition {
 }
 
 impl PartialPosition {
+    #[inline(always)]
     fn xor_piece(&mut self, sq: Square, p: Piece) {
         let single = Bitboard::single(sq);
         let (pk, c) = p.to_parts();
         self.player_bb[c.array_index()] ^= single;
         self.piece_bb[pk.array_index()] ^= single;
     }
+    #[inline(always)]
     fn piece_at(&self, sq: Square) -> Option<Piece> {
-        let index = sq.index() - 1;
-        *unsafe { self.board.get_unchecked(index as usize) }
+        self.board[sq.array_index()]
     }
+    #[inline(always)]
     fn piece_at_mut(&mut self, sq: Square) -> &mut Option<Piece> {
-        let index = sq.index() - 1;
-        unsafe { self.board.get_unchecked_mut(index as usize) }
+        &mut self.board[sq.array_index()]
     }
+    #[inline(always)]
     fn hand_of_a_player(&self, c: Color) -> Hand {
-        *unsafe { self.hands.get_unchecked((c as u8 - 1) as usize) }
+        self.hands[c.array_index()]
     }
+    #[inline(always)]
     fn hand_of_a_player_mut(&mut self, c: Color) -> &mut Hand {
-        unsafe { self.hands.get_unchecked_mut((c as u8 - 1) as usize) }
+        &mut self.hands[c.array_index()]
     }
+    #[inline(always)]
     fn occupied_bitboard(&self) -> Bitboard {
         self.player_bb[0] | self.player_bb[1]
     }
+    #[inline(always)]
     fn king_position(&self, c: Color) -> Option<Square> {
         (self.player_bb[c.array_index()] & self.piece_bb[PieceKind::King.array_index()]).pop()
     }
@@ -405,12 +428,15 @@ impl AttackInfo {
             Bitboard::empty()
         }
     }
+    #[inline(always)]
     pub fn checkers(&self) -> Bitboard {
         self.checkers
     }
+    #[inline(always)]
     pub fn pinned(&self, c: Color) -> Bitboard {
         self.pinned[c.array_index()]
     }
+    #[inline(always)]
     pub fn checkable(&self, pk: PieceKind, sq: Square) -> bool {
         self.checkables[pk.array_index()].contains(sq)
     }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -52,6 +52,7 @@ impl PieceAttackTable {
         }
         Self(table)
     }
+    #[inline(always)]
     pub(crate) fn attack(&self, sq: Square, c: Color) -> Bitboard {
         self.0[sq.array_index()][c.array_index()]
     }
@@ -89,9 +90,11 @@ impl LanceAttackTable {
         }
         Self { masks }
     }
+    #[inline(always)]
     fn pseudo_attack(&self, sq: Square, c: Color) -> Bitboard {
         self.masks[sq.array_index()][c.array_index()]
     }
+    #[inline(always)]
     pub(crate) fn attack(&self, sq: Square, c: Color, occ: &Bitboard) -> Bitboard {
         let mask = self.masks[sq.array_index()][c.array_index()];
         match c {
@@ -125,9 +128,11 @@ impl SlidingAttackTable {
             merged_masks,
         }
     }
+    #[inline(always)]
     fn pseudo_attack(&self, sq: Square) -> Bitboard {
         self.merged_masks[sq.array_index()]
     }
+    #[inline(always)]
     pub(crate) fn attack(&self, sq: Square, occ: &Bitboard) -> Bitboard {
         let masks = self.masks[sq.array_index()];
         occ.sliding_negatives(&masks[0]) | occ.sliding_positives(&masks[1])


### PR DESCRIPTION
- Remove needless dereferences
- Add inline attributes


Benchmark results of `main` branch:
```
test movegen::bench_legal_moves_from_default ... bench:         934 ns/iter (+/- 212)
test movegen::bench_legal_moves_maximum      ... bench:       3,452 ns/iter (+/- 203)

test perft::bench_perft_3_from_maximum_moves ... bench: 276,255,127 ns/iter (+/- 11,050,061)
test perft::bench_perft_5_from_default       ... bench: 320,198,552 ns/iter (+/- 5,421,506)
```

Benchmark results of this branch:
```
test movegen::bench_legal_moves_from_default ... bench:         878 ns/iter (+/- 35)
test movegen::bench_legal_moves_maximum      ... bench:       3,347 ns/iter (+/- 84)

test perft::bench_perft_3_from_maximum_moves ... bench: 251,215,303 ns/iter (+/- 4,981,781)
test perft::bench_perft_5_from_default       ... bench: 280,564,996 ns/iter (+/- 3,973,011)
```