### PR TITLE
SIMD Bitboard

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
 [build]
 rustflags = ["-C", "target-cpu=native"]
-
-[target.'cfg(all(target_arch = "x86_64", target_feature = "lzcnt"))']
-rustflags = ["-C", "target-cpu=native", "-C", "target-feature=+lzcnt"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --verbose
+      run: |
+        cargo build --verbose
+        cargo build --verbose --features simd
     - name: Run tests
-      run: cargo test --verbose
+      run: |
+        cargo test --verbose
+        cargo test --verbose --features simd
 
   clippy_check:
     runs-on: ubuntu-latest
@@ -36,7 +40,7 @@ jobs:
     - name: Install nightly
       run: rustup toolchain install nightly
     - name: Benchmark
-      run: cargo +nightly bench perft::bench_perft_5 | tee bench-output.txt
+      run: cargo +nightly bench --features simd perft::bench_perft_5 | tee bench-output.txt
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,15 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+simd = []
+
 [dependencies]
 arrayvec = "0.7.2"
 once_cell = "1.9.0"
 rand = "0.8.5"
 shogi_core = "0.1.4"
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 shogi_usi_parser = "0.1.0"

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -24,3 +24,33 @@ cfg_if::cfg_if! {
         pub(crate) use self::core::Bitboard;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shogi_core::Square;
+
+    #[test]
+    fn empty() {
+        let bb = Bitboard::empty();
+        assert!(bb.is_empty());
+    }
+
+    #[test]
+    fn bit_ops() {
+        let bb0 = Bitboard::empty();
+        let bb1 = Bitboard::single(Square::SQ_1A);
+        assert_eq!(bb0, bb0 & bb1);
+        assert_eq!(bb1, bb0 | bb1);
+        assert_eq!(bb1, bb0 ^ bb1);
+
+        let mut bb = Bitboard::empty();
+        assert_eq!(bb0, bb);
+        bb |= bb1;
+        assert_eq!(bb1, bb);
+        bb &= bb1;
+        assert_eq!(bb1, bb);
+        bb ^= bb1;
+        assert_eq!(bb0, bb);
+    }
+}

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -15,7 +15,7 @@ cfg_if::cfg_if! {
     if #[cfg(all(
         feature = "simd",
         target_arch = "x86_64",
-        target_feature = "sse4.1"
+        target_feature = "avx2"
     ))] {
         mod x86_64;
         pub(crate) use self::x86_64::Bitboard;

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -32,8 +32,7 @@ mod tests {
 
     #[test]
     fn empty() {
-        let bb = Bitboard::empty();
-        assert!(bb.is_empty());
+        assert!(Bitboard::empty().is_empty());
     }
 
     #[test]
@@ -80,10 +79,13 @@ mod tests {
 
     #[test]
     fn shift() {
-        let bb_1a = Bitboard::single(Square::SQ_1A);
-        assert_eq!(Bitboard::single(Square::SQ_1B), bb_1a.shl());
-
-        let bb_9i = Bitboard::single(Square::SQ_9I);
-        assert_eq!(Bitboard::single(Square::SQ_9H), bb_9i.shr());
+        assert_eq!(
+            Bitboard::single(Square::SQ_1B),
+            Bitboard::single(Square::SQ_1A).shl()
+        );
+        assert_eq!(
+            Bitboard::single(Square::SQ_9H),
+            Bitboard::single(Square::SQ_9I).shr()
+        );
     }
 }

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -2,8 +2,8 @@ pub(crate) trait Occupied
 where
     Self: Sized,
 {
-    fn shl(&self, rhs: u8) -> Self;
-    fn shr(&self, rhs: u8) -> Self;
+    fn shl(&self) -> Self;
+    fn shr(&self) -> Self;
     fn sliding_positive(&self, mask: &Self) -> Self;
     fn sliding_negative(&self, mask: &Self) -> Self;
     fn sliding_positives(&self, masks: &[Self; 2]) -> Self;
@@ -37,6 +37,14 @@ mod tests {
     }
 
     #[test]
+    fn contains() {
+        for sq in Square::all() {
+            let bb = Bitboard::single(sq);
+            assert!(bb.contains(sq));
+        }
+    }
+
+    #[test]
     fn bit_ops() {
         let bb0 = Bitboard::empty();
         let bb1 = Bitboard::single(Square::SQ_1A);
@@ -52,5 +60,30 @@ mod tests {
         assert_eq!(bb1, bb);
         bb ^= bb1;
         assert_eq!(bb0, bb);
+    }
+
+    #[test]
+    fn pop() {
+        assert_eq!(None, Bitboard::empty().pop());
+        for sq in Square::all() {
+            let mut bb = Bitboard::single(sq);
+            assert_eq!(Some(sq), bb.pop());
+            assert!(bb.is_empty());
+            assert_eq!(None, bb.pop());
+        }
+        assert_eq!(Vec::<Square>::new(), Bitboard::empty().collect::<Vec<_>>());
+        assert_eq!(
+            Square::all().collect::<Vec<_>>(),
+            (!Bitboard::empty()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn shift() {
+        let bb_1a = Bitboard::single(Square::SQ_1A);
+        assert_eq!(Bitboard::single(Square::SQ_1B), bb_1a.shl());
+
+        let bb_9i = Bitboard::single(Square::SQ_9I);
+        assert_eq!(Bitboard::single(Square::SQ_9H), bb_9i.shr());
     }
 }

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -2,6 +2,8 @@ pub(crate) trait Occupied
 where
     Self: Sized,
 {
+    fn shl(&self, rhs: u8) -> Self;
+    fn shr(&self, rhs: u8) -> Self;
     fn sliding_positive(&self, mask: &Self) -> Self;
     fn sliding_negative(&self, mask: &Self) -> Self;
     fn sliding_positives(&self, masks: &[Self; 2]) -> Self;
@@ -9,5 +11,16 @@ where
     fn vacant_files(&self) -> Self;
 }
 
-mod core;
-pub(crate) use self::core::Bitboard;
+cfg_if::cfg_if! {
+    if #[cfg(all(
+        feature = "simd",
+        target_arch = "x86_64",
+        target_feature = "sse4.1"
+    ))] {
+        mod x86_64;
+        pub(crate) use self::x86_64::Bitboard;
+    } else {
+        mod core;
+        pub(crate) use self::core::Bitboard;
+    }
+}

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -4,8 +4,8 @@ where
 {
     fn shl(&self) -> Self;
     fn shr(&self) -> Self;
-    fn sliding_positive(&self, mask: &Self) -> Self;
-    fn sliding_negative(&self, mask: &Self) -> Self;
+    fn sliding_positive_consecutive(&self, mask: &Self) -> Self;
+    fn sliding_negative_consecutive(&self, mask: &Self) -> Self;
     fn sliding_positives(&self, masks: &[Self; 2]) -> Self;
     fn sliding_negatives(&self, masks: &[Self; 2]) -> Self;
     fn vacant_files(&self) -> Self;

--- a/src/bitboard/core.rs
+++ b/src/bitboard/core.rs
@@ -95,12 +95,12 @@ const MASKED_BBS: [Bitboard; Square::NUM + 2] = [
 
 impl Occupied for Bitboard {
     #[inline(always)]
-    fn shl(&self, rhs: u8) -> Self {
-        unsafe { self.shift_down(rhs) }
+    fn shl(&self) -> Self {
+        unsafe { self.shift_down(1) }
     }
     #[inline(always)]
-    fn shr(&self, rhs: u8) -> Self {
-        unsafe { self.shift_up(rhs) }
+    fn shr(&self) -> Self {
+        unsafe { self.shift_up(1) }
     }
     #[inline(always)]
     fn sliding_positive(&self, mask: &Self) -> Self {

--- a/src/bitboard/core.rs
+++ b/src/bitboard/core.rs
@@ -93,6 +93,18 @@ const MASKED_BBS: [Bitboard; Square::NUM + 2] = [
     unsafe { Bitboard::from_u128_unchecked((1 << 82) - 1) },
 ];
 
+#[inline(always)]
+fn sliding_positive(bb: &Bitboard, mask: &Bitboard) -> Bitboard {
+    let tz = (*bb & *mask | BB_9I).to_u128().trailing_zeros();
+    *mask & MASKED_BBS[tz as usize + 1]
+}
+
+#[inline(always)]
+fn sliding_negative(bb: &Bitboard, mask: &Bitboard) -> Bitboard {
+    let lz = (*bb & *mask | BB_1A).to_u128().leading_zeros();
+    *mask & !MASKED_BBS[127 - lz as usize]
+}
+
 impl Occupied for Bitboard {
     #[inline(always)]
     fn shl(&self) -> Self {
@@ -103,22 +115,20 @@ impl Occupied for Bitboard {
         unsafe { self.shift_up(1) }
     }
     #[inline(always)]
-    fn sliding_positive(&self, mask: &Self) -> Self {
-        let tz = (*self & *mask | BB_9I).to_u128().trailing_zeros();
-        *mask & MASKED_BBS[tz as usize + 1]
+    fn sliding_positive_consecutive(&self, mask: &Self) -> Self {
+        sliding_positive(self, mask)
     }
     #[inline(always)]
-    fn sliding_negative(&self, mask: &Self) -> Self {
-        let lz = (*self & *mask | BB_1A).to_u128().leading_zeros();
-        *mask & !MASKED_BBS[127 - lz as usize]
+    fn sliding_negative_consecutive(&self, mask: &Self) -> Self {
+        sliding_negative(self, mask)
     }
     #[inline(always)]
     fn sliding_positives(&self, masks: &[Self; 2]) -> Self {
-        self.sliding_positive(&masks[0]) | self.sliding_positive(&masks[1])
+        sliding_positive(self, &masks[0]) | sliding_positive(self, &masks[1])
     }
     #[inline(always)]
     fn sliding_negatives(&self, masks: &[Self; 2]) -> Self {
-        self.sliding_negative(&masks[0]) | self.sliding_negative(&masks[1])
+        sliding_negative(self, &masks[0]) | sliding_negative(self, &masks[1])
     }
     #[inline(always)]
     fn vacant_files(&self) -> Self {

--- a/src/bitboard/core.rs
+++ b/src/bitboard/core.rs
@@ -94,6 +94,12 @@ const MASKED_BBS: [Bitboard; Square::NUM + 2] = [
 ];
 
 impl Occupied for Bitboard {
+    fn shl(&self, rhs: u8) -> Self {
+        unsafe { self.shift_down(rhs) }
+    }
+    fn shr(&self, rhs: u8) -> Self {
+        unsafe { self.shift_up(rhs) }
+    }
     fn sliding_positive(&self, mask: &Self) -> Self {
         let tz = (*self & *mask | BB_9I).to_u128().trailing_zeros();
         *mask & MASKED_BBS[tz as usize + 1]

--- a/src/bitboard/x86_64.rs
+++ b/src/bitboard/x86_64.rs
@@ -1,0 +1,124 @@
+use super::Occupied;
+use shogi_core::Square;
+use std::arch::x86_64;
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Bitboard(x86_64::__m128i);
+
+impl Bitboard {
+    #[inline(always)]
+    pub fn empty() -> Self {
+        Self(unsafe { x86_64::_mm_setzero_si128() })
+    }
+    #[inline(always)]
+    pub const fn single(square: Square) -> Self {
+        todo!()
+    }
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        unsafe { x86_64::_mm_test_all_zeros(self.0, self.0) == 1 }
+    }
+    pub fn contains(self, square: Square) -> bool {
+        todo!()
+    }
+    pub const unsafe fn shift_down(self, delta: u8) -> Self {
+        todo!()
+    }
+    pub const unsafe fn shift_up(self, delta: u8) -> Self {
+        todo!()
+    }
+    pub fn pop(&mut self) -> Option<Square> {
+        todo!()
+    }
+}
+
+impl Occupied for Bitboard {
+    fn shl(&self, rhs: u8) -> Self {
+        todo!()
+    }
+    fn shr(&self, rhs: u8) -> Self {
+        todo!()
+    }
+    fn sliding_positive(&self, mask: &Self) -> Self {
+        todo!()
+    }
+
+    fn sliding_negative(&self, mask: &Self) -> Self {
+        todo!()
+    }
+
+    fn sliding_positives(&self, masks: &[Self; 2]) -> Self {
+        todo!()
+    }
+
+    fn sliding_negatives(&self, masks: &[Self; 2]) -> Self {
+        todo!()
+    }
+
+    fn vacant_files(&self) -> Self {
+        todo!()
+    }
+}
+
+impl BitAnd for Bitboard {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl BitAndAssign for Bitboard {
+    fn bitand_assign(&mut self, rhs: Self) {
+        todo!()
+    }
+}
+
+impl BitOr for Bitboard {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl BitOrAssign for Bitboard {
+    fn bitor_assign(&mut self, rhs: Self) {
+        todo!()
+    }
+}
+
+impl BitXor for Bitboard {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self {
+        todo!()
+    }
+}
+
+impl BitXorAssign for Bitboard {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        todo!()
+    }
+}
+
+impl Not for Bitboard {
+    type Output = Self;
+
+    fn not(self) -> Self {
+        todo!()
+    }
+}
+
+impl Iterator for Bitboard {
+    type Item = Square;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.pop()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(81))
+    }
+}

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -90,8 +90,8 @@ impl Position {
     fn generate_for_fu(&self, av: &mut ArrayVec<Move, MAX_LEGAL_MOVES>, target: &Bitboard) {
         let c = self.side_to_move();
         let (to_bb, delta) = [
-            (unsafe { self.piece_bitboard(Piece::B_P).shift_up(1) }, 1),
-            (unsafe { self.piece_bitboard(Piece::W_P).shift_down(1) }, !0),
+            (self.piece_bitboard(Piece::B_P).shr(1), 1),
+            (self.piece_bitboard(Piece::W_P).shl(1), !0),
         ][c.array_index()];
         for to in to_bb & *target {
             let from = unsafe { Square::from_u8_unchecked(to.index().wrapping_add(delta)) };

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -90,8 +90,8 @@ impl Position {
     fn generate_for_fu(&self, av: &mut ArrayVec<Move, MAX_LEGAL_MOVES>, target: &Bitboard) {
         let c = self.side_to_move();
         let (to_bb, delta) = [
-            (self.piece_bitboard(Piece::B_P).shr(1), 1),
-            (self.piece_bitboard(Piece::W_P).shl(1), !0),
+            (self.piece_bitboard(Piece::B_P).shr(), 1),
+            (self.piece_bitboard(Piece::W_P).shl(), !0),
         ][c.array_index()];
         for to in to_bb & target {
             let from = unsafe { Square::from_u8_unchecked(to.index().wrapping_add(delta)) };

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -98,8 +98,8 @@ impl LanceAttackTable {
     pub(crate) fn attack(&self, sq: Square, c: Color, occ: &Bitboard) -> Bitboard {
         let mask = self.masks[sq.array_index()][c.array_index()];
         match c {
-            Color::Black => occ.sliding_negative(&mask),
-            Color::White => occ.sliding_positive(&mask),
+            Color::Black => occ.sliding_negative_consecutive(&mask),
+            Color::White => occ.sliding_positive_consecutive(&mask),
         }
     }
 }


### PR DESCRIPTION
- Implement `x86_64` Bitboard (`target_feature = "avx2"`)

Reference benchmark results of current `main` branch:
```
test movegen::bench_legal_moves_from_default ... bench:         868 ns/iter (+/- 26)
test movegen::bench_legal_moves_maximum      ... bench:       3,343 ns/iter (+/- 263)

test perft::bench_perft_3_from_maximum_moves ... bench: 321,368,386 ns/iter (+/- 25,436,785)
test perft::bench_perft_5_from_default       ... bench: 380,586,822 ns/iter (+/- 67,586,591)
```
(MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports), 2.8 GHz Quad-Core Intel Core i7, 16 GB 2133 MHz LPDDR3)