### PR TITLE
Improve Bitboard iterator for x86_64

### DIFF
--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -62,22 +62,6 @@ mod tests {
     }
 
     #[test]
-    fn pop() {
-        assert_eq!(None, Bitboard::empty().pop());
-        for sq in Square::all() {
-            let mut bb = Bitboard::single(sq);
-            assert_eq!(Some(sq), bb.pop());
-            assert!(bb.is_empty());
-            assert_eq!(None, bb.pop());
-        }
-        assert_eq!(Vec::<Square>::new(), Bitboard::empty().collect::<Vec<_>>());
-        assert_eq!(
-            Square::all().collect::<Vec<_>>(),
-            (!Bitboard::empty()).collect::<Vec<_>>()
-        );
-    }
-
-    #[test]
     fn shift() {
         assert_eq!(
             Bitboard::single(Square::SQ_1B),

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -71,7 +71,7 @@ impl Position {
             if checkers_count > 1 {
                 return;
             }
-            if let Some(ch) = self.checkers().pop() {
+            if let Some(ch) = self.checkers().into_iter().next() {
                 let target_drop = BETWEEN_TABLE[ch.array_index()][king.array_index()];
                 let target_move = target_drop | self.checkers();
                 self.generate_for_fu(av, &target_move);
@@ -301,7 +301,7 @@ impl Position {
                     .vacant_files();
                 // 打ち歩詰めチェック
                 if let Some(sq) = self.king_position(c.flip()) {
-                    if let Some(to) = ATTACK_TABLE.fu.attack(sq, c.flip()).pop() {
+                    if let Some(to) = ATTACK_TABLE.fu.attack(sq, c.flip()).into_iter().next() {
                         if target.contains(to) && self.is_pawn_drop_mate(to) {
                             target &= !Bitboard::single(to);
                         }

--- a/src/position.rs
+++ b/src/position.rs
@@ -310,7 +310,9 @@ impl PartialPosition {
     }
     #[inline(always)]
     fn king_position(&self, c: Color) -> Option<Square> {
-        (self.player_bb[c.array_index()] & self.piece_bb[PieceKind::King.array_index()]).pop()
+        (self.player_bb[c.array_index()] & self.piece_bb[PieceKind::King.array_index()])
+            .into_iter()
+            .next()
     }
 }
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -262,7 +262,7 @@ mod tests {
             ];
             for (sq, c, expected) in test_cases {
                 let bb = ATTACK_TABLE.ky.attack(sq, c, &pos.occupied_bitboard());
-                assert_eq!(expected, bb.collect::<Vec<_>>());
+                assert_eq!(expected, bb.into_iter().collect::<Vec<_>>());
             }
         }
         {
@@ -293,7 +293,7 @@ mod tests {
                 let bb = ATTACK_TABLE
                     .ky
                     .attack(sq, Color::Black, &pos.occupied_bitboard());
-                assert_eq!(expected, bb.collect::<Vec<_>>());
+                assert_eq!(expected, bb.into_iter().collect::<Vec<_>>());
             }
         }
         {
@@ -324,7 +324,7 @@ mod tests {
                 let bb = ATTACK_TABLE
                     .ky
                     .attack(sq, Color::White, &pos.occupied_bitboard());
-                assert_eq!(expected, bb.collect::<Vec<_>>());
+                assert_eq!(expected, bb.into_iter().collect::<Vec<_>>());
             }
         }
     }
@@ -340,7 +340,7 @@ mod tests {
                 ];
                 for (sq, expected) in test_cases {
                     let bb = ATTACK_TABLE.ka.attack(sq, &pos.occupied_bitboard());
-                    assert_eq!(expected, bb.collect::<Vec<_>>());
+                    assert_eq!(expected, bb.into_iter().collect::<Vec<_>>());
                 }
             }
             {
@@ -360,7 +360,7 @@ mod tests {
                 ];
                 for (sq, expected) in test_cases {
                     let bb = ATTACK_TABLE.hi.attack(sq, &pos.occupied_bitboard());
-                    assert_eq!(expected, bb.collect::<Vec<_>>());
+                    assert_eq!(expected, bb.into_iter().collect::<Vec<_>>());
                 }
             }
         }


### PR DESCRIPTION
Further improvement of #17.

`cargo +nightly bench --features simd`

```
test movegen::bench_legal_moves_from_default ... bench:         867 ns/iter (+/- 28)
test movegen::bench_legal_moves_maximum      ... bench:       2,601 ns/iter (+/- 133)

test perft::bench_perft_3_from_maximum_moves ... bench: 195,768,368 ns/iter (+/- 2,592,367)
test perft::bench_perft_5_from_default       ... bench: 223,235,300 ns/iter (+/- 5,434,342)
```
(MacBook Pro (13-inch, 2019, Four Thunderbolt 3 ports), 2.8 GHz Quad-Core Intel Core i7, 16 GB 2133 MHz LPDDR3)